### PR TITLE
According to the manual -qq or quiet level 2 implies -y

### DIFF
--- a/quickinstall.sh
+++ b/quickinstall.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# Copyright 2016, jgamblin, released under the MIT License 
+# Copyright 2016, jgamblin, released under the MIT License
 # See https://github.com/jgamblin/quickinstall/blob/master/LICENSE for the
 # complete license text
 # Source code at https://github.com/jgamblin/quickinstall
 
 # Upgrade installed packages to latest
 echo -e "\nRunning a package upgrade...\n"
-apt-get -qq -y update && apt-get -qq -y dist-upgrade
+apt-get -qq update && apt-get -qq dist-upgrade
 
 
 #Install stuff I use all the time
 echo -e "\nInstalling default packages...\n"
-apt-get -qq -y install build-essential checkinstall docker.io fail2ban git git-core libbz2-dev libc6-dev libgdbm-dev libncursesw5-dev libreadline-gplv2-dev libsqlite3-dev libssl-dev nikto nmap nodejs python-dev python-numpy python-scipy python-setuptools tk-dev unattended-upgrades ufw
+apt-get -qq install build-essential checkinstall docker.io fail2ban git git-core libbz2-dev libc6-dev libgdbm-dev libncursesw5-dev libreadline-gplv2-dev libsqlite3-dev libssl-dev nikto nmap nodejs python-dev python-numpy python-scipy python-setuptools tk-dev unattended-upgrades ufw
 
 
 #Install and configure firewall


### PR DESCRIPTION
apt-get install still produces some output at least on debian. To remedy this you can use "> /dev/null" in the end of the line.
