### PR TITLE
Log ufw to separate file

### DIFF
--- a/quickinstall.sh
+++ b/quickinstall.sh
@@ -23,6 +23,10 @@ ufw allow ssh
 sed -i.bak 's/ENABLED=no/ENABLED=yes/g' /etc/ufw/ufw.conf
 chmod 0644 /etc/ufw/ufw.conf
 
+#Log ufw to separate file
+sed -i '/~/s/^#//g' /etc/rsyslog.d/20-ufw.conf
+/etc/init.d/rsyslog restart
+
 # set timezone to UTC
 echo -e "\nUpdating Timezone to UTC...\n"
 sudo timedatectl set-timezone UTC


### PR DESCRIPTION
Keeping ufw logs separated makes it easier in the future to handle firewall issues.
